### PR TITLE
Enable isolatedModules

### DIFF
--- a/base.json
+++ b/base.json
@@ -13,6 +13,9 @@
     // enable JS only as needed on per-project basis
     "allowJs": false,
 
+    // required to support esbuild, babel, and similar transpilers
+    "isolatedModules": true,
+
     // support fast package rebuilds
     "composite": true,
 


### PR DESCRIPTION
This flag was already set in studio: https://github.com/foxglove/studio/blob/21c0f51d8ff3fedad6804eb62124032e5b604b2d/packages/tsconfig/tsconfig.base.json#L14-L15

Given the comment on that line, I wasn't sure whether it was necessary for projects not using `babel-jest`. However, it is also recommended by esbuild ( https://esbuild.github.io/content-types/#isolated-modules ).

It is also fairly non-invasive, so better to keep on by default.