### PR TITLE
Set `composite: false` by default to avoid .tsbuildinfo files in package archives

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.prettierPath": "./node_modules/prettier",
+  "files.associations": {
+    "base.json": "jsonc"
+  },
   "files.eol": "\n"
 }

--- a/base.json
+++ b/base.json
@@ -1,6 +1,7 @@
 // -*- jsonc -*-
 // Base TypeScript configuration
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     // build es2020 modules by default
     "module": "es2020",
@@ -16,8 +17,10 @@
     // required to support esbuild, babel, and similar transpilers
     "isolatedModules": true,
 
-    // support fast package rebuilds
+    // ensure support for fast incremental package rebuilds, but disable them by default to avoid
+    // .tsbuildinfo files being accidentally included in package archives
     "composite": true,
+    "incremental": false,
 
     // produce consistent output across all platforms
     "newLine": "lf",

--- a/base.json
+++ b/base.json
@@ -17,9 +17,9 @@
     // required to support esbuild, babel, and similar transpilers
     "isolatedModules": true,
 
-    // ensure support for fast incremental package rebuilds, but disable them by default to avoid
-    // .tsbuildinfo files being accidentally included in package archives
-    "composite": true,
+    // disable composite/incremental builds by default to prevent .tsbuildinfo files from being
+    // accidentally included in package archives
+    "composite": false,
     "incremental": false,
 
     // produce consistent output across all platforms


### PR DESCRIPTION
Installing a package based on this tsconfig from a git commit could lead to checksum mismatches, because the `.tsbuildinfo` was included in the package archive but its contents are platform-specific (for example, filenames are lowercased on macOS to support case-insensitivity).

By setting `composite: false`, we don't produce any .tsbuildinfo files by default. Individual projects may enable this setting if desired, though they should take care not to include the .tsbuildinfo in build products.