### PR TITLE
Change build target to ESNext

### DIFF
--- a/base.json
+++ b/base.json
@@ -3,10 +3,10 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    // build es2020 modules by default
-    "module": "es2020",
-    "target": "es2020",
-    "lib": ["es2020"],
+    // build esnext modules by default
+    "module": "esnext",
+    "target": "esnext",
+    "lib": ["esnext"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "importHelpers": true,


### PR DESCRIPTION
**Public-Facing Changes**
Change build target to `esnext` to enable the use of `#` private identifiers natively.