### PR TITLE
Modernize base config, introduce node and bundler configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: yarn install
       - run: yarn fmt:check
       - run: yarn lint:check
-      - run: yarn build
+      - run: yarn test
 
       # Publish version tags
       - name: npm publish

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,3 @@
-// -*- jsonc -*-
 {
   "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,11 @@
-// -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "prettier.prettier-vscode",
   "files.associations": {
-    "base.json": "jsonc"
+    "*.json": "jsonc"
   },
   "files.eol": "\n",
   "files.insertFinalNewline": true,

--- a/README.md
+++ b/README.md
@@ -4,15 +4,59 @@
 
 Base tsconfig for Foxglove projects.
 
-To use, run `yarn add -D @foxglove/tsconfig`, then extend your `tsconfig.json` like so:
+## Requirements
+
+- TypeScript v5.8+
+
+## Installation
+
+```sh
+yarn add -D @foxglove/tsconfig
+```
+
+## Usage
+
+Choose the config that matches your environment:
+
+### Node.js applications and libraries
 
 ```json
 {
-  "extends": "@foxglove/tsconfig/base",
+  "extends": "@foxglove/tsconfig/node.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"
+  }
+}
+```
+
+> **Note:** Uses `target: "ESNext"`. For older Node.js versions, set a lower target (e.g., `"ES2022"` for Node 18).
+
+> **Cross-platform libraries:** Use `node.json` even if your library will be used in frontend apps. Bundlers consume Node-style packages natively—just avoid Node-specific APIs like `fs` or `process`.
+
+### Frontend applications (Vite, Webpack, esbuild, etc)
+
+For bundled apps that run in the browser (not published as packages):
+
+```json
+{
+  "extends": "@foxglove/tsconfig/bundler.json",
+  "include": ["./src/**/*"]
+}
+```
+
+### Base config
+
+Provides strict type-checking and modern defaults, but no `module`, `moduleResolution`, or `target` settings. Use this when `node.json` and `bundler.json` don't fit your environment:
+
+```json
+{
+  "extends": "@foxglove/tsconfig/base.json",
+  "compilerOptions": {
+    "target": "...",
+    "module": "...",
+    "moduleResolution": "..."
   }
 }
 ```

--- a/base.json
+++ b/base.json
@@ -1,51 +1,38 @@
 // -*- jsonc -*-
 // Base TypeScript configuration
+// You typically shouldn't extend from this file directly
+// See `node.json` and `bundler.json` for environment-specific settings
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    // build es2022 modules by default
-    "module": "es2022",
-    "target": "es2022",
-    "lib": ["es2022"],
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "importHelpers": true,
-
-    // enable JS only as needed on per-project basis
-    "allowJs": false,
-
-    // required to support esbuild, babel, and similar transpilers
-    "isolatedModules": true,
-
-    // disable composite/incremental builds by default to prevent .tsbuildinfo files from being
-    // accidentally included in package archives
-    "composite": false,
-    "incremental": false,
-
-    // produce consistent output across all platforms
-    "newLine": "lf",
-
-    // allow typed JSON imports
-    "resolveJsonModule": true,
-
-    // produce .js.map, .d.ts and .d.ts.map files when emit is enabled
-    "noEmit": false,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-
-    // recommended for faster compilation
-    "skipLibCheck": true,
-
-    // be as strict as possible, but no stricter
+    // Type checking
     "strict": true,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
+    "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitOverride": true,
-    "forceConsistentCasingInFileNames": true
+
+    // Modules
+    "erasableSyntaxOnly": true,
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+
+    // Interop
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+
+    // Emit
+    "declaration": true,
+    "declarationMap": true,
+    "isolatedDeclarations": true,
+    "newLine": "lf",
+    "sourceMap": true,
+
+    // Performance
+    "skipLibCheck": true
   }
 }

--- a/bundler.json
+++ b/bundler.json
@@ -1,0 +1,13 @@
+// -*- jsonc -*-
+// TypeScript configuration for frontend/bundled applications (Webpack, esbuild, etc)
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    // Bundler handles module resolution
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.AsyncIterable", "DOM.Iterable"]
+  }
+}

--- a/node.json
+++ b/node.json
@@ -1,0 +1,12 @@
+// -*- jsonc -*-
+// TypeScript configuration for Node.js applications and libraries
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    // Node.js ESM
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/tsconfig",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Base TypeScript configuration for Foxglove projects",
   "license": "MIT",
   "repository": {
@@ -14,16 +14,18 @@
     "url": "https://foxglove.dev/"
   },
   "packageManager": "yarn@4.12.0",
+  "type": "module",
   "files": [
-    "base.json"
+    "base.json",
+    "node.json",
+    "bundler.json"
   ],
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "yarn clean && tsc --project base.json --outDir dist",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "lint": "eslint --fix .",
-    "lint:check": "eslint ."
+    "lint:check": "eslint .",
+    "test": "tsc -p test/node.tsconfig.json && tsc -p test/bundler.tsconfig.json"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.1.0",

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,0 @@
-// This file exists so that we can test tsc
-export default function test(): number {
-  return 42;
-}

--- a/test/bundler.ts
+++ b/test/bundler.ts
@@ -1,0 +1,5 @@
+// Validates bundler.json config
+export const test = "bundler";
+
+// Verify DOM types are available
+export const el: HTMLElement | null = null;

--- a/test/bundler.tsconfig.json
+++ b/test/bundler.tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../bundler.json",
+  "include": ["bundler.ts"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,0 +1,8 @@
+// Validates node.json config
+export interface Config {
+  name: string;
+}
+
+export const config: Config = {
+  name: "node",
+};

--- a/test/node.tsconfig.json
+++ b/test/node.tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../node.json",
+  "include": ["node.ts"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
This PR:

- Updates our `base.json` with modern strict defaults for 2026
- Introduces `node.json` and `bundler.json` with environment-specific configs

This will support modernization of our code, allowing use of features such as native TypeScript execution in Node.js, and simplifying module output for bundlers.

It will be a breaking change for consumers, so will need to publish as a major version (although it is easy for consumers to disable any settings they have not yet adopted).

### New base.json settings

| Setting | Old Value | New Value | Why It's a Good Default |
|---------|-----------|-----------|------------------------|
| **Type Checking** ||||
| `strict` | `true` | `true` | Enables all strict type-checking options (`strictNullChecks`, `strictFunctionTypes`, `noImplicitAny`, etc.) — catches bugs at compile time |
| `noFallthroughCasesInSwitch` | `true` | `true` | Errors on switch case fallthrough without explicit `break`/`return` — prevents accidental bugs |
| `noImplicitAny` | `true` | *(removed)* | Redundant — already enabled by `strict: true` (per docs: "Default: `true` if strict") |
| `noImplicitOverride` | `true` | `true` | Requires `override` keyword when overriding base class methods — makes inheritance explicit |
| `noImplicitReturns` | `true` | `true` | Errors when a function doesn't return a value in all code paths |
| `noUncheckedIndexedAccess` | `true` | `true` | Adds `undefined` to index signature types — prevents assuming array/object access always succeeds |
| `noUnusedLocals` | `true` | `true` | Errors on unused local variables — keeps code clean |
| `noUnusedParameters` | `true` | `true` | Errors on unused function parameters |
| **Modules** ||||
| `module` | `"es2022"` | *(removed)* | Moved to `node.json`/`bundler.json` — environment-specific |
| `target` | `"es2022"` | *(removed)* | Moved to `node.json`/`bundler.json` — environment-specific |
| `lib` | `["es2022"]` | *(removed)* | Moved to `node.json`/`bundler.json` — environment-specific |
| `moduleResolution` | `"node"` | *(removed)* | Moved to `node.json`/`bundler.json` — environment-specific |
| `esModuleInterop` | `true` | *(removed)* | Replaced by `verbatimModuleSyntax` which is stricter and more explicit |
| `importHelpers` | `true` | *(removed)* | Not needed with modern ESNext targets — helpers are native |
| `allowJs` | `false` | *(removed)* | Redundant — default is already `false` |
| `erasableSyntaxOnly` | *(default: false)* | `true` | **New in TS 5.8** — Only allows erasable type syntax (no enums, namespaces) — enables Node.js `--experimental-strip-types` or tsx |
| `noUncheckedSideEffectImports` | *(default: false)* | `true` | **New in TS 5.6** — Verifies side-effect imports resolve to real files — catches typos |
| `resolveJsonModule` | `true` | `true` | Allows importing `.json` files with type inference |
| `rewriteRelativeImportExtensions` | *(default: false)* | `true` | **New in TS 5.7** — Rewrites `.ts` imports to `.js` in output — write imports with source extensions |
| `verbatimModuleSyntax` | *(default: false)* | `true` | **New in TS 5.0** — Requires explicit `import type` — ensures correct ESM output and tree-shaking |
| **Interop** ||||
| `forceConsistentCasingInFileNames` | `true` | `true` | Errors on inconsistent file casing in imports — prevents cross-platform issues. Default: `true` (since TS 5.0) |
| `isolatedModules` | `true` | `true` | Ensures each file can be transpiled independently — required for esbuild, Babel, swc |
| **Emit** ||||
| `composite` | `false` | *(removed)* | Redundant — default is already `false` |
| `incremental` | `false` | *(removed)* | Redundant — default is `false` when composite is false |
| `noEmit` | `false` | *(removed)* | Redundant — default is already `false` |
| `declaration` | `true` | `true` | Generates `.d.ts` type declaration files |
| `declarationMap` | `true` | `true` | Generates `.d.ts.map` files — enables "Go to Definition" to navigate to source |
| `isolatedDeclarations` | *(default: false)* | `true` | **New in TS 5.5** — Requires explicit return types on exports — enables parallel declaration emit |
| `newLine` | `"lf"` | `"lf"` | Uses Unix line endings — consistent output across platforms. Default: `lf` |
| `sourceMap` | `true` | `true` | Generates `.js.map` files — enables debugging with original source |
| **Performance** ||||
| `skipLibCheck` | `true` | `true` | Skips type-checking `.d.ts` files — significantly faster builds |