### PR TITLE
Use yarn npm publish with OIDC for trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       # Publish version tags
       - name: npm publish
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn npm publish --access public --provenance --tag test
+        run: yarn npm publish --access public --provenance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       # Publish version tags
       - name: npm publish
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn npm publish --access public --tag test
+        run: yarn npm publish --access public --provenance --tag test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       # Publish version tags
       - name: npm publish
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npx npm@latest publish --provenance --access public
+        run: yarn npm publish --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       # Publish version tags
       - name: npm publish
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn npm publish --access public
+        run: yarn npm publish --access public --tag test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/tsconfig",
-  "version": "2.0.1-trusted-publishing-test.2",
+  "version": "2.0.0",
   "description": "Base TypeScript configuration for Foxglove projects",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/tsconfig",
-  "version": "2.0.0",
+  "version": "2.0.1-trusted-publishing-test.1",
   "description": "Base TypeScript configuration for Foxglove projects",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/tsconfig",
-  "version": "2.0.1-trusted-publishing-test.1",
+  "version": "2.0.1-trusted-publishing-test.2",
   "description": "Base TypeScript configuration for Foxglove projects",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Update npm publish workflow to use OIDC trusted publishing with provenance.

## Changes
- Add `id-token: write` and `contents: read` permissions for OIDC authentication
- Update to `npx npm@11.7.0 publish` with `--provenance` flag for supply chain security
- Update actions to v6
- Remove `NODE_AUTH_TOKEN` secret (no longer needed with OIDC)

## Status
✅ Trusted publishing has been configured on npmjs.com for this package.