### PR TITLE
Enable NPM trusted publishing with OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       # Publish version tags
       - name: npm publish
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npx npm@latest publish --provenance --access public --tag test
+        run: npx npm@latest publish --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     steps:
       - uses: actions/checkout@v6
 
@@ -30,7 +35,5 @@ jobs:
 
       # Publish version tags
       - name: npm publish
-        run: npm publish --access public
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npx npm@latest publish --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       # Publish version tags
       - name: npm publish
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npx npm@latest publish --provenance --access public
+        run: npx npm@latest publish --provenance --access public --tag test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/tsconfig",
-  "version": "2.0.0",
+  "version": "2.0.1-trusted-publishing-test.0",
   "description": "Base TypeScript configuration for Foxglove projects",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/tsconfig",
-  "version": "2.0.1-trusted-publishing-test.0",
+  "version": "2.0.0",
   "description": "Base TypeScript configuration for Foxglove projects",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Enable NPM trusted publishing using OIDC tokens instead of long-lived `NODE_AUTH_TOKEN` secrets.

## Changes
- Added `permissions: id-token: write` and `contents: read` for OIDC authentication
- Removed `NODE_AUTH_TOKEN` environment variable
- Updated to `yarn npm publish --access public --provenance`
- Updated repository URL to `git+https://` format
- Upgraded to Yarn 4.12.0 with corepack