### PR TITLE
Remove lib override from bundler.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ Uses `module: "Preserve"` which allows extensionless imports (e.g., `import { fo
 ```json
 {
   "extends": "@foxglove/tsconfig/bundler.json",
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "noEmit": true
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Choose the config that matches your environment:
 
 ### Node.js applications and libraries
 
-Uses `module: "NodeNext"` which enforces Node.js ESM rules—imports must include explicit file extensions (e.g., `import { foo } from "./bar.js"`).
+Uses `module: "NodeNext"` which enforces Node.js ESM rules—imports must include explicit file extensions (e.g., `import { foo } from "./bar.ts"`).
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Uses `module: "NodeNext"` which enforces Node.js ESM rules—imports must includ
 
 ### Bundled applications (Vite, Webpack, esbuild, etc)
 
-Uses `module: "Preserve"` which allows extensionless imports (e.g., `import { foo } from "./bar"`)—the bundler handles resolution.
+Uses `module: "Preserve"` which allows extensionless imports (e.g., `import { foo } from "./bar"`, where the bundler handles resolution.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Choose the config that matches your environment:
 
 > **Note:** Uses `target: "ESNext"`. For older Node.js versions, set a lower target (e.g., `"ES2022"` for Node 18).
 
-> **Cross-platform libraries:** Use `node.json` even if your library will be used in frontend apps. Bundlers consume Node-style packages natively—just avoid Node-specific APIs like `fs` or `process`.
+> **Cross-platform libraries:** Use `node.json` even if your library will be used in bundled apps. Bundlers consume Node-style packages natively—just avoid Node-specific APIs like `fs` or `process`.
 
-### Frontend applications (Vite, Webpack, esbuild, etc)
+### Bundled applications (Vite, Webpack, esbuild, etc)
 
 For bundled apps that run in the browser (not published as packages):
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Provides strict type-checking and modern defaults, but no `module` or `moduleRes
 {
   "extends": "@foxglove/tsconfig/base.json",
   "compilerOptions": {
-    "target": "...",
     "module": "...",
     "moduleResolution": "..."
   }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Choose the config that matches your environment:
 
 ### Node.js applications and libraries
 
-Uses `module: "NodeNext"` which enforces Node.js ESM rules—imports must include explicit file extensions (e.g., `import { foo } from "./bar.ts"`).
+Uses `module: "NodeNext"` which enforces Node.js ESM rules, where imports must include explicit file extensions (e.g., `import { foo } from "./bar.ts"`).
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Uses `module: "Preserve"` which allows extensionless imports (e.g., `import { fo
   "extends": "@foxglove/tsconfig/bundler.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "lib": ["ESNext", "DOM"]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Choose the config that matches your environment:
 
 ### Node.js applications and libraries
 
+Uses `module: "NodeNext"` which enforces Node.js ESM rules—imports must include explicit file extensions (e.g., `import { foo } from "./bar.js"`).
+
 ```json
 {
   "extends": "@foxglove/tsconfig/node.json",
@@ -37,7 +39,7 @@ Choose the config that matches your environment:
 
 ### Bundled applications (Vite, Webpack, esbuild, etc)
 
-For bundled apps that run in the browser (not published as packages):
+Uses `module: "Preserve"` which allows extensionless imports (e.g., `import { foo } from "./bar"`)—the bundler handles resolution.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For bundled apps that run in the browser (not published as packages):
 
 ### Base config
 
-Provides strict type-checking and modern defaults, but no `module`, `moduleResolution`, or `target` settings. Use this when `node.json` and `bundler.json` don't fit your environment:
+Provides strict type-checking and modern defaults, but no `module` or `moduleResolution` settings. Use this when `node.json` and `bundler.json` don't fit your environment:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Uses `module: "NodeNext"` which enforces Node.js ESM rules, where imports must i
 
 > **Note:** Uses `target: "ESNext"`. For older Node.js versions, set a lower target (e.g., `"ES2022"` for Node 18).
 
-> **Cross-platform libraries:** Use `node.json` even if your library will be used in bundled apps. Bundlers consume Node-style packages natively—just avoid Node-specific APIs like `fs` or `process`.
+> **Cross-platform libraries:** Use `node.json` even if your library will be used in bundled apps. Bundlers consume Node-style packages natively, just remember to avoid Node-specific APIs like `fs` or `process`.
 
 ### Bundled applications (Vite, Webpack, esbuild, etc)
 

--- a/base.json
+++ b/base.json
@@ -5,6 +5,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    // Language
+    "target": "ESNext",
+
     // Type checking
     "strict": true,
     "noFallthroughCasesInSwitch": true,

--- a/bundler.json
+++ b/bundler.json
@@ -7,7 +7,6 @@
     // Bundler handles module resolution
     "module": "Preserve",
     "moduleResolution": "Bundler",
-    "target": "ESNext",
-    "lib": ["ESNext", "DOM", "DOM.AsyncIterable", "DOM.Iterable"]
+    "target": "ESNext"
   }
 }

--- a/bundler.json
+++ b/bundler.json
@@ -6,7 +6,6 @@
   "compilerOptions": {
     // Bundler handles module resolution
     "module": "Preserve",
-    "moduleResolution": "Bundler",
-    "target": "ESNext"
+    "moduleResolution": "Bundler"
   }
 }

--- a/node.json
+++ b/node.json
@@ -6,7 +6,6 @@
   "compilerOptions": {
     // Node.js ESM
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "target": "ESNext"
+    "moduleResolution": "NodeNext"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/tsconfig",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Base TypeScript configuration for Foxglove projects",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Remove `lib` override from `bundler.json`. 

It felt like we were conflating frontend/backend with node/bundler, but these are not always true. The `lib` override is removed from `bundler.json`, and consumers are free to override it when DOM types are needed. 

---
<a href="https://cursor.com/background-agent?bcId=bc-ed1ee403-bca6-46ef-ae33-b5cf5c7d97b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed1ee403-bca6-46ef-ae33-b5cf5c7d97b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

