### PR TITLE
Remove isolatedDeclarations

### DIFF
--- a/base.json
+++ b/base.json
@@ -31,7 +31,6 @@
     // Emit
     "declaration": true,
     "declarationMap": true,
-    "isolatedDeclarations": true,
     "newLine": "lf",
     "sourceMap": true,
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/tsconfig",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Base TypeScript configuration for Foxglove projects",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The `isolatedDeclarations` setting introduced in https://github.com/foxglove/tsconfig/pull/7 has proven to be overkill.

It theoretically helps speed up builds, but only for dependent packages, and does not help at all when declarations are not created (e.g. `noEmit: true` for bundled code).

Easier for specific packages to set this if they find a performance improvement, rather than the majority of packages needing to disable it.